### PR TITLE
Change title headings to h1

### DIFF
--- a/src/components/Pricing.js
+++ b/src/components/Pricing.js
@@ -1,40 +1,40 @@
-import React from 'react'
-import PropTypes from 'prop-types'
+import React from "react";
+import PropTypes from "prop-types";
 
 const Pricing = ({ data }) => (
-  <div className="columns">
-    {data.map(price => (
-      <div key={price.plan} className="column">
-        <section className="section">
-          <h4 className="has-text-centered has-text-weight-semibold">
-            {price.plan}
-          </h4>
-          <h2 className="is-size-1 has-text-weight-bold has-text-primary has-text-centered">
-            ${price.price}
-          </h2>
-          <p className="has-text-weight-semibold">{price.description}</p>
-          <ul>
-            {price.items.map(item => (
-              <li key={item} className="is-size-5">
-                {item}
-              </li>
-            ))}
-          </ul>
-        </section>
-      </div>
-    ))}
-  </div>
-)
+	<div className="columns">
+		{data.map(price => (
+			<div key={price.plan} className="column">
+				<section className="section">
+					<h4 className="has-text-centered has-text-weight-semibold">
+						{price.plan}
+					</h4>
+					<h1 className="is-size-1 has-text-weight-bold has-text-primary has-text-centered">
+						${price.price}
+					</h1>
+					<p className="has-text-weight-semibold">{price.description}</p>
+					<ul>
+						{price.items.map(item => (
+							<li key={item} className="is-size-5">
+								{item}
+							</li>
+						))}
+					</ul>
+				</section>
+			</div>
+		))}
+	</div>
+);
 
 Pricing.propTypes = {
-  data: PropTypes.arrayOf(
-    PropTypes.shape({
-      plan: PropTypes.string,
-      price: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-      description: PropTypes.string,
-      items: PropTypes.array,
-    })
-  ),
-}
+	data: PropTypes.arrayOf(
+		PropTypes.shape({
+			plan: PropTypes.string,
+			price: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+			description: PropTypes.string,
+			items: PropTypes.array
+		})
+	)
+};
 
-export default Pricing
+export default Pricing;

--- a/src/templates/groups-directory.js
+++ b/src/templates/groups-directory.js
@@ -5,63 +5,63 @@ import Layout from "../components/Layout";
 import Content, { HTMLContent } from "../components/Content";
 
 export const GroupsDirectoryTemplate = ({
-  title,
-  content,
-  contentComponent
+	title,
+	content,
+	contentComponent
 }) => {
-  const PageContent = contentComponent || Content;
+	const PageContent = contentComponent || Content;
 
-  return (
-    <section className="section section--gradient">
-      <div className="container">
-        <div className="columns">
-          <div className="column is-10 is-offset-1">
-            <div className="section">
-              <h2 className="title is-size-3 has-text-weight-bold is-bold-light">
-                {title}
-              </h2>
-              <PageContent className="content" content={content} />
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
+	return (
+		<section className="section section--gradient">
+			<div className="container">
+				<div className="columns">
+					<div className="column is-10 is-offset-1">
+						<div className="section">
+							<h1 className="title is-size-3 has-text-weight-bold is-bold-light">
+								{title}
+							</h1>
+							<PageContent className="content" content={content} />
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
 };
 
 GroupsDirectoryTemplate.propTypes = {
-  title: PropTypes.string.isRequired,
-  content: PropTypes.string,
-  contentComponent: PropTypes.func
+	title: PropTypes.string.isRequired,
+	content: PropTypes.string,
+	contentComponent: PropTypes.func
 };
 
 const GroupsDirectory = ({ data }) => {
-  const { markdownRemark: post } = data;
+	const { markdownRemark: post } = data;
 
-  return (
-    <Layout>
-      <GroupsDirectoryTemplate
-        contentComponent={HTMLContent}
-        title={post.frontmatter.title}
-        content={post.html}
-      />
-    </Layout>
-  );
+	return (
+		<Layout>
+			<GroupsDirectoryTemplate
+				contentComponent={HTMLContent}
+				title={post.frontmatter.title}
+				content={post.html}
+			/>
+		</Layout>
+	);
 };
 
 GroupsDirectory.propTypes = {
-  data: PropTypes.object.isRequired
+	data: PropTypes.object.isRequired
 };
 
 export default GroupsDirectory;
 
 export const aboutPageQuery = graphql`
-  query GroupsDirectory($id: String!) {
-    markdownRemark(id: { eq: $id }) {
-      html
-      frontmatter {
-        title
-      }
-    }
-  }
+	query GroupsDirectory($id: String!) {
+		markdownRemark(id: { eq: $id }) {
+			html
+			frontmatter {
+				title
+			}
+		}
+	}
 `;

--- a/src/templates/index-page.js
+++ b/src/templates/index-page.js
@@ -5,59 +5,59 @@ import Layout from "../components/Layout";
 import Content, { HTMLContent } from "../components/Content";
 
 export const IndexPageTemplate = ({ title, content, contentComponent }) => {
-  const PageContent = contentComponent || Content;
+	const PageContent = contentComponent || Content;
 
-  return (
-    <section className="section section--gradient">
-      <div className="container">
-        <div className="columns">
-          <div className="column is-10 is-offset-1">
-            <div className="section">
-              <h2 className="title is-size-3 has-text-weight-bold is-bold-light">
-                {title}
-              </h2>
-              <PageContent className="content" content={content} />
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
+	return (
+		<section className="section section--gradient">
+			<div className="container">
+				<div className="columns">
+					<div className="column is-10 is-offset-1">
+						<div className="section">
+							<h1 className="title is-size-3 has-text-weight-bold is-bold-light">
+								{title}
+							</h1>
+							<PageContent className="content" content={content} />
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
 };
 
 IndexPageTemplate.propTypes = {
-  title: PropTypes.string.isRequired,
-  content: PropTypes.string,
-  contentComponent: PropTypes.func
+	title: PropTypes.string.isRequired,
+	content: PropTypes.string,
+	contentComponent: PropTypes.func
 };
 
 const IndexPage = ({ data }) => {
-  const { markdownRemark: post } = data;
+	const { markdownRemark: post } = data;
 
-  return (
-    <Layout>
-      <IndexPageTemplate
-        contentComponent={HTMLContent}
-        title={post.frontmatter.title}
-        content={post.html}
-      />
-    </Layout>
-  );
+	return (
+		<Layout>
+			<IndexPageTemplate
+				contentComponent={HTMLContent}
+				title={post.frontmatter.title}
+				content={post.html}
+			/>
+		</Layout>
+	);
 };
 
 IndexPage.propTypes = {
-  data: PropTypes.object.isRequired
+	data: PropTypes.object.isRequired
 };
 
 export default IndexPage;
 
 export const aboutPageQuery = graphql`
-  query IndexPage($id: String!) {
-    markdownRemark(id: { eq: $id }) {
-      html
-      frontmatter {
-        title
-      }
-    }
-  }
+	query IndexPage($id: String!) {
+		markdownRemark(id: { eq: $id }) {
+			html
+			frontmatter {
+				title
+			}
+		}
+	}
 `;

--- a/src/templates/info-page.js
+++ b/src/templates/info-page.js
@@ -5,59 +5,59 @@ import Layout from "../components/Layout";
 import Content, { HTMLContent } from "../components/Content";
 
 export const PageTemplate = ({ title, content, contentComponent }) => {
-  const PageContent = contentComponent || Content;
+	const PageContent = contentComponent || Content;
 
-  return (
-    <section className="section section--gradient">
-      <div className="container">
-        <div className="columns">
-          <div className="column is-10 is-offset-1">
-            <div className="section">
-              <h2 className="title is-size-3 has-text-weight-bold is-bold-light">
-                {title}
-              </h2>
-              <PageContent className="content" content={content} />
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
+	return (
+		<section className="section section--gradient">
+			<div className="container">
+				<div className="columns">
+					<div className="column is-10 is-offset-1">
+						<div className="section">
+							<h1 className="title is-size-3 has-text-weight-bold is-bold-light">
+								{title}
+							</h1>
+							<PageContent className="content" content={content} />
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
 };
 
 PageTemplate.propTypes = {
-  title: PropTypes.string.isRequired,
-  content: PropTypes.string,
-  contentComponent: PropTypes.func
+	title: PropTypes.string.isRequired,
+	content: PropTypes.string,
+	contentComponent: PropTypes.func
 };
 
 const Page = ({ data }) => {
-  const { markdownRemark: post } = data;
+	const { markdownRemark: post } = data;
 
-  return (
-    <Layout>
-      <PageTemplate
-        contentComponent={HTMLContent}
-        title={post.frontmatter.title}
-        content={post.html}
-      />
-    </Layout>
-  );
+	return (
+		<Layout>
+			<PageTemplate
+				contentComponent={HTMLContent}
+				title={post.frontmatter.title}
+				content={post.html}
+			/>
+		</Layout>
+	);
 };
 
 Page.propTypes = {
-  data: PropTypes.object.isRequired
+	data: PropTypes.object.isRequired
 };
 
 export default Page;
 
 export const infoPageQuery = graphql`
-  query InfoPage($id: String!) {
-    markdownRemark(id: { eq: $id }) {
-      html
-      frontmatter {
-        title
-      }
-    }
-  }
+	query InfoPage($id: String!) {
+		markdownRemark(id: { eq: $id }) {
+			html
+			frontmatter {
+				title
+			}
+		}
+	}
 `;

--- a/src/templates/patterns.js
+++ b/src/templates/patterns.js
@@ -6,68 +6,68 @@ import Layout from "../components/Layout";
 import Content, { HTMLContent } from "../components/Content";
 // import PATTERN from "../img/MasksNOW-Mask-Pattern-MasksNOW-Mask-Pattern-Packet-by-Created-for-Crisis.png";
 export const PatternsTemplate = ({ title, content, contentComponent }) => {
-  const PageContent = contentComponent || Content;
+	const PageContent = contentComponent || Content;
 
-  return (
-    <section className="section section--gradient">
-      <div className="container">
-        <div className="columns">
-          <div className="column is-10 is-offset-1">
-            <div className="section">
-              <h2 className="title is-size-3 has-text-weight-bold is-bold-light">
-                {title}
-              </h2>
-              <PageContent className="content" content={content} />
+	return (
+		<section className="section section--gradient">
+			<div className="container">
+				<div className="columns">
+					<div className="column is-10 is-offset-1">
+						<div className="section">
+							<h1 className="title is-size-3 has-text-weight-bold is-bold-light">
+								{title}
+							</h1>
+							<PageContent className="content" content={content} />
 
-              <a href="/docs/CFCMask_3_27.pdf">
-                Download the 3 LAYER pattern packet (updated 3-27)
-              </a>
-              <div>
-                <a href="/docs/CFC_Pocket_Mask_3_28.pdf">
-                  Download the POCKET pattern packet (updated 3-28)
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
+							<a href="/docs/CFCMask_3_27.pdf">
+								Download the 3 LAYER pattern packet (updated 3-27)
+							</a>
+							<div>
+								<a href="/docs/CFC_Pocket_Mask_3_28.pdf">
+									Download the POCKET pattern packet (updated 3-28)
+								</a>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
 };
 
 PatternsTemplate.propTypes = {
-  title: PropTypes.string.isRequired,
-  content: PropTypes.string,
-  contentComponent: PropTypes.func
+	title: PropTypes.string.isRequired,
+	content: PropTypes.string,
+	contentComponent: PropTypes.func
 };
 
 const Patterns = ({ data }) => {
-  const { markdownRemark: post } = data;
+	const { markdownRemark: post } = data;
 
-  return (
-    <Layout>
-      <PatternsTemplate
-        contentComponent={HTMLContent}
-        title={post.frontmatter.title}
-        content={post.html}
-      />
-    </Layout>
-  );
+	return (
+		<Layout>
+			<PatternsTemplate
+				contentComponent={HTMLContent}
+				title={post.frontmatter.title}
+				content={post.html}
+			/>
+		</Layout>
+	);
 };
 
 Patterns.propTypes = {
-  data: PropTypes.object.isRequired
+	data: PropTypes.object.isRequired
 };
 
 export default Patterns;
 
 export const aboutPageQuery = graphql`
-  query Patterns($id: String!) {
-    markdownRemark(id: { eq: $id }) {
-      html
-      frontmatter {
-        title
-      }
-    }
-  }
+	query Patterns($id: String!) {
+		markdownRemark(id: { eq: $id }) {
+			html
+			frontmatter {
+				title
+			}
+		}
+	}
 `;

--- a/src/templates/request-supplies.js
+++ b/src/templates/request-supplies.js
@@ -5,70 +5,70 @@ import Layout from "../components/Layout";
 import Content, { HTMLContent } from "../components/Content";
 
 export const RequestSuppliesTemplate = ({
-  title,
-  content,
-  contentComponent
+	title,
+	content,
+	contentComponent
 }) => {
-  const PageContent = contentComponent || Content;
+	const PageContent = contentComponent || Content;
 
-  return (
-    <section className="section section--gradient">
-      <div className="container">
-        <div className="columns">
-          <div className="column is-10 is-offset-1">
-            <div className="section">
-              <h2 className="title is-size-3 has-text-weight-bold is-bold-light">
-                {title}
-              </h2>
-              <PageContent className="content" content={content} />
-              <iframe
-                className="airtable-embed airtable-dynamic-height"
-                src="https://airtable.com/embed/shr5nBY7UkLhrqj4R?backgroundColor=yellow"
-                width="100%"
-                height="1867"
-                className="request-supplies__StyledFrame-ybe9hf-0 diKYNp"
-              ></iframe>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
+	return (
+		<section className="section section--gradient">
+			<div className="container">
+				<div className="columns">
+					<div className="column is-10 is-offset-1">
+						<div className="section">
+							<h1 className="title is-size-3 has-text-weight-bold is-bold-light">
+								{title}
+							</h1>
+							<PageContent className="content" content={content} />
+							<iframe
+								className="airtable-embed airtable-dynamic-height"
+								src="https://airtable.com/embed/shr5nBY7UkLhrqj4R?backgroundColor=yellow"
+								width="100%"
+								height="1867"
+								className="request-supplies__StyledFrame-ybe9hf-0 diKYNp"
+							></iframe>
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
 };
 
 RequestSuppliesTemplate.propTypes = {
-  title: PropTypes.string.isRequired,
-  content: PropTypes.string,
-  contentComponent: PropTypes.func
+	title: PropTypes.string.isRequired,
+	content: PropTypes.string,
+	contentComponent: PropTypes.func
 };
 
 const RequestSupplies = ({ data }) => {
-  const { markdownRemark: post } = data;
+	const { markdownRemark: post } = data;
 
-  return (
-    <Layout>
-      <RequestSuppliesTemplate
-        contentComponent={HTMLContent}
-        title={post.frontmatter.title}
-        content={post.html}
-      />
-    </Layout>
-  );
+	return (
+		<Layout>
+			<RequestSuppliesTemplate
+				contentComponent={HTMLContent}
+				title={post.frontmatter.title}
+				content={post.html}
+			/>
+		</Layout>
+	);
 };
 
 RequestSupplies.propTypes = {
-  data: PropTypes.object.isRequired
+	data: PropTypes.object.isRequired
 };
 
 export default RequestSupplies;
 
 export const aboutPageQuery = graphql`
-  query RequestSupplies($id: String!) {
-    markdownRemark(id: { eq: $id }) {
-      html
-      frontmatter {
-        title
-      }
-    }
-  }
+	query RequestSupplies($id: String!) {
+		markdownRemark(id: { eq: $id }) {
+			html
+			frontmatter {
+				title
+			}
+		}
+	}
 `;

--- a/src/templates/tags.js
+++ b/src/templates/tags.js
@@ -4,71 +4,71 @@ import { Link, graphql } from "gatsby";
 import Layout from "../components/Layout";
 
 class TagRoute extends React.Component {
-  render() {
-    const posts = this.props.data.allMarkdownRemark.edges;
-    const postLinks = posts.map(post => (
-      <li key={post.node.fields.slug}>
-        <Link to={post.node.fields.slug}>
-          <h2 className="is-size-2">{post.node.frontmatter.title}</h2>
-        </Link>
-      </li>
-    ));
-    const tag = this.props.pageContext.tag;
-    const title = this.props.data.site.siteMetadata.title;
-    const totalCount = this.props.data.allMarkdownRemark.totalCount;
-    const tagHeader = `${totalCount} post${
-      totalCount === 1 ? "" : "s"
-    } tagged with “${tag}”`;
+	render() {
+		const posts = this.props.data.allMarkdownRemark.edges;
+		const postLinks = posts.map(post => (
+			<li key={post.node.fields.slug}>
+				<Link to={post.node.fields.slug}>
+					<h1 className="is-size-2">{post.node.frontmatter.title}</h1>
+				</Link>
+			</li>
+		));
+		const tag = this.props.pageContext.tag;
+		const title = this.props.data.site.siteMetadata.title;
+		const totalCount = this.props.data.allMarkdownRemark.totalCount;
+		const tagHeader = `${totalCount} post${
+			totalCount === 1 ? "" : "s"
+		} tagged with “${tag}”`;
 
-    return (
-      <Layout>
-        <section className="section">
-          <Helmet title={`${tag} | ${title}`} />
-          <div className="container content">
-            <div className="columns">
-              <div
-                className="column is-10 is-offset-1"
-                style={{ marginBottom: "6rem" }}
-              >
-                <h3 className="title is-size-4 is-bold-light">{tagHeader}</h3>
-                <ul className="taglist">{postLinks}</ul>
-                <p>
-                  <Link to="/tags/">Browse all tags</Link>
-                </p>
-              </div>
-            </div>
-          </div>
-        </section>
-      </Layout>
-    );
-  }
+		return (
+			<Layout>
+				<section className="section">
+					<Helmet title={`${tag} | ${title}`} />
+					<div className="container content">
+						<div className="columns">
+							<div
+								className="column is-10 is-offset-1"
+								style={{ marginBottom: "6rem" }}
+							>
+								<h3 className="title is-size-4 is-bold-light">{tagHeader}</h3>
+								<ul className="taglist">{postLinks}</ul>
+								<p>
+									<Link to="/tags/">Browse all tags</Link>
+								</p>
+							</div>
+						</div>
+					</div>
+				</section>
+			</Layout>
+		);
+	}
 }
 
 export default TagRoute;
 
 export const tagPageQuery = graphql`
-  query TagPage($tag: String) {
-    site {
-      siteMetadata {
-        title
-      }
-    }
-    allMarkdownRemark(
-      limit: 1000
-      sort: { fields: [frontmatter___date], order: DESC }
-      filter: { frontmatter: { tags: { in: [$tag] } } }
-    ) {
-      totalCount
-      edges {
-        node {
-          fields {
-            slug
-          }
-          frontmatter {
-            title
-          }
-        }
-      }
-    }
-  }
+	query TagPage($tag: String) {
+		site {
+			siteMetadata {
+				title
+			}
+		}
+		allMarkdownRemark(
+			limit: 1000
+			sort: { fields: [frontmatter___date], order: DESC }
+			filter: { frontmatter: { tags: { in: [$tag] } } }
+		) {
+			totalCount
+			edges {
+				node {
+					fields {
+						slug
+					}
+					frontmatter {
+						title
+					}
+				}
+			}
+		}
+	}
 `;

--- a/src/templates/volunteer.js
+++ b/src/templates/volunteer.js
@@ -5,65 +5,65 @@ import Layout from "../components/Layout";
 import Content, { HTMLContent } from "../components/Content";
 
 export const VolunteerTemplate = ({ title, content, contentComponent }) => {
-  const PageContent = contentComponent || Content;
+	const PageContent = contentComponent || Content;
 
-  return (
-    <section className="section section--gradient">
-      <div className="container">
-        <div className="columns">
-          <div className="column is-10 is-offset-1">
-            <div className="section">
-              <h2 className="title is-size-3 has-text-weight-bold is-bold-light">
-                {title}
-              </h2>
-              <PageContent className="content" content={content} />
-              <iframe
-                className="airtable-embed airtable-dynamic-height"
-                src="https://airtable.com/embed/shrtdAwqaNjZwgVbm?backgroundColor=green"
-                width="100%"
-                height="1096"
-              ></iframe>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
+	return (
+		<section className="section section--gradient">
+			<div className="container">
+				<div className="columns">
+					<div className="column is-10 is-offset-1">
+						<div className="section">
+							<h1 className="title is-size-3 has-text-weight-bold is-bold-light">
+								{title}
+							</h1>
+							<PageContent className="content" content={content} />
+							<iframe
+								className="airtable-embed airtable-dynamic-height"
+								src="https://airtable.com/embed/shrtdAwqaNjZwgVbm?backgroundColor=green"
+								width="100%"
+								height="1096"
+							></iframe>
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
 };
 
 VolunteerTemplate.propTypes = {
-  title: PropTypes.string.isRequired,
-  content: PropTypes.string,
-  contentComponent: PropTypes.func
+	title: PropTypes.string.isRequired,
+	content: PropTypes.string,
+	contentComponent: PropTypes.func
 };
 
 const Volunteer = ({ data }) => {
-  const { markdownRemark: post } = data;
+	const { markdownRemark: post } = data;
 
-  return (
-    <Layout>
-      <VolunteerTemplate
-        contentComponent={HTMLContent}
-        title={post.frontmatter.title}
-        content={post.html}
-      />
-    </Layout>
-  );
+	return (
+		<Layout>
+			<VolunteerTemplate
+				contentComponent={HTMLContent}
+				title={post.frontmatter.title}
+				content={post.html}
+			/>
+		</Layout>
+	);
 };
 
 Volunteer.propTypes = {
-  data: PropTypes.object.isRequired
+	data: PropTypes.object.isRequired
 };
 
 export default Volunteer;
 
 export const aboutPageQuery = graphql`
-  query Volunteer($id: String!) {
-    markdownRemark(id: { eq: $id }) {
-      html
-      frontmatter {
-        title
-      }
-    }
-  }
+	query Volunteer($id: String!) {
+		markdownRemark(id: { eq: $id }) {
+			html
+			frontmatter {
+				title
+			}
+		}
+	}
 `;


### PR DESCRIPTION
I started PR #63 to address SEO component.
In #7 @gvan12 said

> it's important for PSAs page to make the H1 "PSAs" that way google doesn't think the first celebrity endoresement is the title.

The SEO rule, as I understand it, is one h1 tag per page, and that should be title of the page.  Right now, many but not all templates use h2 for the title. 

This PR changes all page titles to use h1 tags for headings.

