### PR TITLE
feat(404): add page with text, link to /contact

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -38,7 +38,7 @@ const NotFoundPage = () => (
           role="img"
           aria-label="A yellow face with closed eyes wearing a white surgical mask, as used by health workers in hospitals. "
         >
-          😷4
+          😷
         </span>
         4
       </Title>

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,12 +1,52 @@
 import React from 'react';
 import Layout from '../components/Layout';
+import styled from 'styled-components';
+import { Link } from 'gatsby';
+
+const Container = styled.div`
+  width: 50%;
+  min-height: 350px;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  padding: 2.5rem 0;
+  margin: 0 auto;
+
+  text-align: center;
+`;
+
+const Title = styled.h1`
+  font-size: 72px;
+  font-weight: bold;
+  color: #1c376e;
+`;
+
+const Subtitle = styled.p`
+  font-size: 36px;
+  color: #1c376e;
+`;
 
 const NotFoundPage = () => (
   <Layout>
-    <div>
-      <h1>NOT FOUND</h1>
-      <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
-    </div>
+    <Container>
+      <Title>
+        4
+        <span
+          role="img"
+          aria-label="A yellow face with closed eyes wearing a white surgical mask, as used by health workers in hospitals. "
+        >
+          😷4
+        </span>
+        4
+      </Title>
+      <Subtitle>
+        Sorry, we couldn't find that page. If you think this is a problem,
+        please <Link to="/contact">contact us.</Link>
+      </Subtitle>
+    </Container>
   </Layout>
 );
 


### PR DESCRIPTION
Proposing this layout:
![image](https://user-images.githubusercontent.com/14146176/78088531-cd047280-739a-11ea-9fa4-c1dac129f2ca.png)

Created the page using only `styled` components. Couldn't find a guide regarding how the project are approaching styles right now.

Took care of the accessibility issue by wrapping the emoji inside a `span` tag.

Closes #56 