### PR TITLE
Fix: front page edit to make it more obvious that we accept all mask patterns

### DIFF
--- a/src/components/ListCard.js
+++ b/src/components/ListCard.js
@@ -110,6 +110,11 @@ export const WarningText = styled.span`
   margin: -0.5em 0 0 2.5em;
 `;
 
+export const AdditionalInfoText = styled.span`
+  font-style: italic;
+  margin: ${props => (props.hasLeftSpacing ? "0 0.5em" : 0)};
+`;
+
 export const InfoBannerWrapper = styled.div`
   // font-size should be 3em to match the CTA buttons but it's wrong for some reason
   font-size: 2em;

--- a/src/components/ListCard.js
+++ b/src/components/ListCard.js
@@ -112,7 +112,7 @@ export const WarningText = styled.span`
 
 export const AdditionalInfoText = styled.span`
   font-style: italic;
-  margin: ${props => (props.hasLeftSpacing ? "0 0.5em" : 0)};
+  margin: ${props => (props.hasLeftSpacing ? '0 0.5em' : 0)};
 `;
 
 export const InfoBannerWrapper = styled.div`

--- a/src/pages/infographic-page.js
+++ b/src/pages/infographic-page.js
@@ -10,6 +10,7 @@ import {
   StyledLink,
   TextLink,
   WarningText,
+  AdditionalInfoText,
 } from '../components/ListCard';
 
 const InfographicPage = () => {
@@ -59,6 +60,9 @@ const InfographicPage = () => {
       <InfoCard image={data.pattern.childImageSharp.fluid}>
         <InfoCardRight>
           <h2>Get The Pattern</h2>
+          <AdditionalInfoText hasLeftSpacing>
+            (or use any pattern of your choosing)
+          </AdditionalInfoText>
           <InfoCardAnchor href={'/docs/CFCMask_3_27.pdf'}>
             3-LAYER FACE MASK
           </InfoCardAnchor>
@@ -100,6 +104,15 @@ const InfographicPage = () => {
             <br />
             {`DIRECTIONS ABOUT HOW & WHERE`}
           </StyledLink>
+          <TextLink
+            href={
+              'https://rosiesews.freshdesk.com/support/solutions/articles/61000268414-can-i-use-a-different-pattern-than-what-you-provide-'
+            }
+          >
+            {`EVERY MASK MADE WILL BE DONATED`}
+            <br />
+            {`NO MATTER WHAT PATTERN YOU USE`}
+          </TextLink>
         </InfoCardRight>
       </InfoCard>
       <InfoCard image={data.question.childImageSharp.fluid}>


### PR DESCRIPTION
Fixes #88 

![image](https://user-images.githubusercontent.com/22222078/79054598-8b02e880-7c46-11ea-8542-b916e942eeac.png)

**EVERY MASK MADE WILL BE DONATED NO MATTER WHAT PATTERN YOU USE** links to: https://rosiesews.freshdesk.com/support/solutions/articles/61000268414-can-i-use-a-different-pattern-than-what-you-provide-