### PR TITLE
Enforce node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ how's that?
 ### contribute
 
 1. Make a local copy by running `git clone https://github.com/RosieSews/masksnow.git`
-2. Run `yarn` to install dependencies locally
-3. Install `gatsby-cli` with `yarn global add gatsby-cli`
-4. Create a new branch with a description of your feature `git checkout -b FEATURE` - ex. `git checkout -b make-images-responsive`
-5. Work your magic
-6. Add any new files, make your commits, and submit a PR. If you run `git push` your terminal should give you directions that look something like `git push --set-upstream origin FEATURE`. Run that code.
-7. Go to the repo. You should see a banner with a green button that says Compare & Pull Request. Click the button and finish submitting your PR.
+2. Make sure you're running node v12.x since the project doesn't currently build on v13. The `.nvmrc` file specifies the exact version we're currently developing with.
+3. Run `yarn` to install dependencies locally
+4. Install `gatsby-cli` with `yarn global add gatsby-cli`
+5. Create a new branch with a description of your feature `git checkout -b FEATURE` - ex. `git checkout -b make-images-responsive`
+6. Work your magic
+7. Add any new files, make your commits, and submit a PR. If you run `git push` your terminal should give you directions that look something like `git push --set-upstream origin FEATURE`. Run that code.
+8. Go to the repo. You should see a banner with a green button that says Compare & Pull Request. Click the button and finish submitting your PR.
 
 ### run a local dev environment
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "MasksNOW connects mask makers with those in need.",
   "version": "0.1.0",
   "author": "Garrett, Jon, Chaney",
+  "engines": {
+    "node": "12.*"
+  },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-brands-svg-icons": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-plugin-styled-components": "^1.10.7",
     "bulma": "^0.8.0",
     "cleave.js": "^1.5.10",
+    "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "firebase": "^7.14.0",
     "formik": "^2.1.4",
@@ -77,9 +78,9 @@
   "scripts": {
     "clean": "gatsby clean",
     "start": "yarn run develop",
-    "build": "GATSBY_ROSIE_ENV=development yarn run clean && gatsby build",
-    "build:production": "ROSIE_ENV=production yarn run clean && gatsby build",
-    "develop": "GATSBY_ROSIE_ENV=development yarn run clean && gatsby develop",
+    "build": "yarn run clean && cross-env GATSBY_ROSIE_ENV=development gatsby build",
+    "build:production": "yarn run clean && cross-env ROSIE_ENV=production gatsby build",
+    "develop": "yarn run clean && cross-env GATSBY_ROSIE_ENV=development gatsby develop",
     "format": "prettier --config ./prettier.config.js --write \"{gatsby-*.js,src/**/*.js}\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4566,6 +4566,13 @@ create-react-context@0.3.0, create-react-context@^0.3.0:
     gud "^1.0.0"
     warning "^4.0.3"
 
+cross-env@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.2.tgz#bd5ed31339a93a3418ac4f3ca9ca3403082ae5f9"
+  integrity sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-fetch@2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.2.tgz#a47ff4f7fc712daba8f6a695a11c948440d45723"
@@ -4606,6 +4613,15 @@ cross-spawn@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
   integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
+cross-spawn@^7.0.1:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.2.tgz#d0d7dcfa74e89115c7619f4f721a94e1fdb716d6"
+  integrity sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"


### PR DESCRIPTION
Specifies the `engines` field since the project doesn't currently build
on the latest version of node  (v13). Running npm or yarn will now error
out immediately if using a version other than v12 and hopefully prevent
any wasted time for new devs.

also leverage the cross-env package so the build commands that set
environment variables will work on Windows as well as Mac and Linux.