### PR TITLE
Improve SEO for individual pages

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -4,7 +4,7 @@ module.exports = {
   siteTitle: 'MasksNOW', // Navigation and Site Title
   siteTitleAlt: 'The MasksNOW coalition', // Alternative Site title for SEO
   siteTitleManifest: 'masksNOW',
-  siteUrl: 'https://masksnow.org', // Domain of your site. No trailing slash!
+  siteUrl: process.env.GATSBY_ROSIE_URL || 'https://masksnow.org', // Domain of your site. No trailing slash!
   siteLanguage: 'en', // Language Tag on <html> element
   siteHeadline: 'We Can Do It!', // Headline for schema.org JSONLD
   siteBanner: '/img/mn-site-image.png', // Your image for og:image tag. You can find it in the /static folder

--- a/netlify.toml
+++ b/netlify.toml
@@ -19,6 +19,7 @@
   [context.deploy-preview.environment]
     GATSBY_EXPRESS_API_PATH = "https://us-central1-created-for-crisis-development.cloudfunctions.net/app"
     GATSBY_ROSIE_ENV = "deploy-preview"
+    GATSBY_ROSIE_URL = "https://deploy-preview-127--eloquent-montalcini-4aed93.netlify.app"
 
 [context.branch-deploy]
   command = "npm run build"
@@ -26,3 +27,4 @@
   [context.branch-deploy.environment]
     GATSBY_EXPRESS_API_PATH = "https://us-central1-created-for-crisis-development.cloudfunctions.net/app"
     GATSBY_ROSIE_ENV = "branch-deploy"
+    GATSBY_ROSIE_URL = "https://staging--eloquent-montalcini-4aed93.netlify.app"

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -6,12 +6,12 @@ import Navbar from '../components/Navbar';
 import './all.sass';
 import SEO from './SEO';
 import { ThemeProvider } from 'styled-components';
-import { theme, GlobalStyle } from '../styles/theme';
+import { theme } from '../styles/theme';
 
-const TemplateWrapper = ({ children }) => {
+const TemplateWrapper = ({ children, ...otherProps }) => {
   return (
     <ThemeProvider theme={theme}>
-      <SEO />
+      <SEO {...otherProps} />
       <Helmet>
         <link
           rel="icon"

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -5,28 +5,24 @@ import Helmet from 'react-helmet';
 import config from '../../config';
 
 const SEO = props => {
-  const { postNode, postPath, article, buildTime } = props;
+  const { article, description, metaImage, title, pathname } = props;
+  const buildTime = null; //todo: pass this in somehow
 
-  let title;
-  let description;
+  let pageTitle;
+  let pageDescription;
   let keywords;
 
   const realPrefix = config.pathPrefix === '/' ? '' : config.pathPrefix;
   const homeURL = `${config.siteUrl}${realPrefix}`;
-  const URL = `${homeURL}${postPath || ''}`;
-  const image = `${homeURL}${config.siteBanner}`;
+  const URL = `${homeURL}${pathname || ''}`;
+  const image = metaImage
+    ? `${homeURL}${metaImage.src}`
+    : `${homeURL}${config.siteBanner}`;
 
-  if (article) {
-    const postMeta = postNode.frontmatter;
-    title = `${postMeta.title} | ${config.siteTitle}`;
-    description = postNode.excerpt;
-    keywords = postNode.frontmatter.keywords.join();
-  } else {
-    title = config.siteTitleAlt;
-    description = config.siteDescription;
-    keywords =
-      'Donate medical masks, covid19, homemade masks, homemade surgical mask, surgical mask, reuseable masks';
-  }
+  keywords =
+    'Donate medical masks, covid19, homemade masks, homemade surgical mask, surgical mask, reuseable masks';
+  pageTitle = title ? `${title} | ${config.siteTitle}` : config.siteTitleAlt;
+  pageDescription = description ? description : config.siteDescription;
 
   // schema.org in JSONLD format
   // https://developers.google.com/search/docs/guides/intro-structured-data
@@ -113,6 +109,7 @@ const SEO = props => {
 
   let schemaArticle = null;
 
+  //todo: get post dates
   if (article) {
     schemaArticle = {
       '@context': 'http://schema.org',
@@ -125,7 +122,7 @@ const SEO = props => {
         '@type': 'Person',
         name: config.author,
       },
-      copyrightYear: postNode.parent.birthtime,
+      // copyrightYear: postNode.parent.birthtime,
       creator: {
         '@type': 'Person',
         name: config.author,
@@ -138,13 +135,13 @@ const SEO = props => {
           url: `${homeURL}${config.siteLogo}`,
         },
       },
-      datePublished: postNode.parent.birthtime,
-      dateModified: postNode.parent.mtime,
-      description,
-      headline: title,
+      // datePublished: postNode.parent.birthtime,
+      // dateModified: postNode.parent.mtime,
+      description: pageDescription,
+      headline: pageTitle,
       inLanguage: 'en',
       url: URL,
-      name: title,
+      name: pageTitle,
       image: {
         '@type': 'ImageObject',
         url: image,
@@ -156,7 +153,7 @@ const SEO = props => {
       '@type': 'ListItem',
       item: {
         '@id': URL,
-        name: title,
+        name: pageTitle,
       },
       position: 3,
     });
@@ -173,9 +170,9 @@ const SEO = props => {
   return (
     <Helmet>
       <html lang={config.siteLanguage} />
-      <title>{title}</title>
+      <title>{pageTitle}</title>
       <meta name="keywords" content={keywords} />
-      <meta name="description" content={description} />
+      <meta name="description" content={pageDescription} />
       <meta name="image" content={image} />
       <meta name="gatsby-starter" content="Gatsby Starter Minimal Blog" />
       <meta property="og:locale" content={config.ogLanguage} />
@@ -185,12 +182,16 @@ const SEO = props => {
       />
       <meta property="og:url" content={URL} />
       <meta property="og:type" content={article ? 'article' : 'website'} />
-      <meta property="og:title" content={title} />
-      <meta property="og:description" content={description} />
+      <meta property="og:title" content={pageTitle} />
+      <meta property="og:description" content={pageDescription} />
       <meta property="og:image" content={image} />
-      <meta property="og:image:height" content={'600'} />
-      <meta property="og:image:width" content={'600'} />
-      <meta property="og:image:alt" content={description} />
+      {metaImage && (
+        <>
+          <meta property="og:image:height" content={metaImage.height} />
+          <meta property="og:image:width" content={metaImage.width} />
+        </>
+      )}
+      <meta property="og:image:alt" content={pageDescription} />
       {config.siteFBAppID && (
         <meta property="fb:app_id" content={config.siteFBAppID} />
       )}
@@ -199,11 +200,11 @@ const SEO = props => {
         name="twitter:creator"
         content={config.userTwitter ? config.userTwitter : ''}
       />
-      <meta name="twitter:title" content={title} />
-      <meta name="twitter:url" content={config.siteUrl} />
-      <meta name="twitter:description" content={description} />
+      <meta name="twitter:title" content={pageTitle} />
+      <meta name="twitter:url" content={URL} />
+      <meta name="twitter:description" content={pageDescription} />
       <meta name="twitter:image" content={image} />
-      <meta name="twitter:image:alt" content={description} />
+      <meta name="twitter:image:alt" content={pageDescription} />
       {/* Insert schema.org data conditionally (webpage/article) + everytime (breadcrumbs) */}
       {!article && (
         <script type="application/ld+json">
@@ -220,18 +221,19 @@ const SEO = props => {
   );
 };
 
-export default SEO;
+SEO.defaultProps = {
+  description: ``,
+};
 
 SEO.propTypes = {
-  postNode: PropTypes.object,
-  postPath: PropTypes.string,
-  article: PropTypes.bool,
-  buildTime: PropTypes.string,
+  description: PropTypes.string,
+  title: PropTypes.string,
+  metaImage: PropTypes.shape({
+    src: PropTypes.string.isRequired,
+    height: PropTypes.number.isRequired,
+    width: PropTypes.number.isRequired,
+  }),
+  pathname: PropTypes.string,
 };
 
-SEO.defaultProps = {
-  postNode: null,
-  postPath: null,
-  article: false,
-  buildTime: null,
-};
+export default SEO;

--- a/src/lib/fragments.js
+++ b/src/lib/fragments.js
@@ -28,7 +28,7 @@ export const bannerImage = graphql`
 
   fragment featureImage1200 on File {
     childImageSharp {
-      resize(width: 1200, fit: 'contain') {
+      resize(width: 1200, fit: "contain") {
         src
         height
         width

--- a/src/lib/fragments.js
+++ b/src/lib/fragments.js
@@ -28,7 +28,7 @@ export const bannerImage = graphql`
 
   fragment featureImage1200 on File {
     childImageSharp {
-      resize(width: 1200) {
+      resize(width: 1200, fit: 'contain') {
         src
         height
         width

--- a/src/lib/fragments.js
+++ b/src/lib/fragments.js
@@ -28,7 +28,7 @@ export const bannerImage = graphql`
 
   fragment featureImage1200 on File {
     childImageSharp {
-      resize(width: 1200, fit: "contain") {
+      resize(width: 1200, fit: CONTAIN) {
         src
         height
         width

--- a/src/lib/fragments.js
+++ b/src/lib/fragments.js
@@ -25,4 +25,14 @@ export const bannerImage = graphql`
       }
     }
   }
+
+  fragment featureImage1200 on File {
+    childImageSharp {
+      resize(width: 1200) {
+        src
+        height
+        width
+      }
+    }
+  }
 `;

--- a/src/pages/donate.js
+++ b/src/pages/donate.js
@@ -59,13 +59,7 @@ export const donatePageQuery = graphql`
         subTitle
         description
         featuredimage {
-          childImageSharp {
-            resize(width: 1200) {
-              src
-              height
-              width
-            }
-          }
+          ...featureImage1200
         }
       }
     }

--- a/src/pages/donate.js
+++ b/src/pages/donate.js
@@ -7,11 +7,21 @@ import { HTMLContent } from '../components/Content';
 import { AuthUserContext } from '../components/Session';
 import { StyledSection } from '../components/StyledElements/Sections';
 
-const DonatePage = ({ data }) => {
+const DonatePage = ({ data, location }) => {
   const { pageContent } = data;
+  const { frontmatter } = pageContent;
+  const image = frontmatter.featuredimage
+    ? frontmatter.featuredimage.childImageSharp.resize
+    : null;
 
   return (
-    <Layout>
+    <Layout
+      article
+      title={frontmatter.title}
+      description={frontmatter.description}
+      metaImage={image}
+      pathname={location.pathname}
+    >
       <section className="section section--gradient">
         <div className="container">
           <div className="columns">
@@ -50,8 +60,10 @@ export const donatePageQuery = graphql`
         description
         featuredimage {
           childImageSharp {
-            fluid(maxWidth: 150, quality: 100) {
-              ...GatsbyImageSharpFluid
+            resize(width: 1200) {
+              src
+              height
+              width
             }
           }
         }

--- a/src/pages/resources/index.js
+++ b/src/pages/resources/index.js
@@ -6,7 +6,6 @@ import {
   InfoCard,
   InfoCardLink,
   InfoCardRight,
-  InfographicBanner,
 } from '../../components/ListCard';
 import { HTMLContent } from '../../components/Content';
 
@@ -39,20 +38,17 @@ const Resources = ({ resources }) => {
 
 const ResourcesPage = ({ title, data }) => {
   const { resources, pageContent } = data;
-  console.log('pageContent', pageContent);
   return (
-    <Layout>
+    <Layout title={pageContent.frontmatter.title}>
       <section className="section section--gradient">
         <div className="container">
           <div className="columns">
             <div className="column is-10 is-offset-1">
-              {/*<div className="section">*/}
               <h1 className="title is-size-3 has-text-weight-bold is-bold-light">
                 {title}
               </h1>
               <HTMLContent className="content" content={pageContent.html} />
               <Resources resources={resources} />
-              {/*</div>*/}
             </div>
           </div>
         </div>

--- a/src/templates/groups-directory.js
+++ b/src/templates/groups-directory.js
@@ -36,11 +36,15 @@ GroupsDirectoryTemplate.propTypes = {
   contentComponent: PropTypes.func,
 };
 
-const GroupsDirectory = ({ data }) => {
+const GroupsDirectory = ({ data, location }) => {
   const { markdownRemark: post } = data;
 
   return (
-    <Layout>
+    <Layout
+      title={post.frontmatter.title}
+      pathname={location.pathname}
+      description={post.frontmatter.description}
+    >
       <GroupsDirectoryTemplate
         contentComponent={HTMLContent}
         title={post.frontmatter.title}

--- a/src/templates/info-page.js
+++ b/src/templates/info-page.js
@@ -35,12 +35,17 @@ PageTemplate.propTypes = {
 const Page = ({ data, location }) => {
   const { markdownRemark: post } = data;
 
+  const image = post.frontmatter.featuredimage
+    ? post.frontmatter.featuredimage.childImageSharp.resize
+    : null;
+
   return (
     <Layout
       article
       title={post.frontmatter.title}
       pathname={location.pathname}
       description={post.frontmatter.description || post.excerpt}
+      metaImage={image}
     >
       <PageTemplate
         contentComponent={HTMLContent}
@@ -65,6 +70,9 @@ export const infoPageQuery = graphql`
       frontmatter {
         title
         description
+        featuredimage {
+          ...featureImage1200
+        }
       }
     }
   }

--- a/src/templates/info-page.js
+++ b/src/templates/info-page.js
@@ -32,11 +32,16 @@ PageTemplate.propTypes = {
   contentComponent: PropTypes.func,
 };
 
-const Page = ({ data }) => {
+const Page = ({ data, location }) => {
   const { markdownRemark: post } = data;
 
   return (
-    <Layout>
+    <Layout
+      article
+      title={post.frontmatter.title}
+      pathname={location.pathname}
+      description={post.frontmatter.description || post.excerpt}
+    >
       <PageTemplate
         contentComponent={HTMLContent}
         title={post.frontmatter.title}
@@ -56,8 +61,10 @@ export const infoPageQuery = graphql`
   query InfoPage($id: String!) {
     markdownRemark(id: { eq: $id }) {
       html
+      excerpt(pruneLength: 160)
       frontmatter {
         title
+        description
       }
     }
   }

--- a/src/templates/patterns.js
+++ b/src/templates/patterns.js
@@ -117,13 +117,7 @@ export const aboutPageQuery = graphql`
           }
         }
         featuredimage: patternArt {
-          childImageSharp {
-            resize(width: 1200) {
-              src
-              height
-              width
-            }
-          }
+          ...featureImage1200
         }
       }
     }

--- a/src/templates/patterns.js
+++ b/src/templates/patterns.js
@@ -64,11 +64,20 @@ PatternsTemplate.propTypes = {
   contentComponent: PropTypes.func,
 };
 
-const Patterns = ({ data }) => {
+const Patterns = ({ data, location }) => {
   const { markdownRemark: post } = data;
+  const { frontmatter } = post;
+  const image = frontmatter.featuredimage
+    ? frontmatter.featuredimage.childImageSharp.resize
+    : null;
 
   return (
-    <Layout>
+    <Layout
+      description={post.frontmatter.description}
+      title={frontmatter.title}
+      pathname={location.pathname}
+      metaImage={image}
+    >
       <PatternsTemplate
         contentComponent={HTMLContent}
         {...post.frontmatter}
@@ -104,6 +113,15 @@ export const aboutPageQuery = graphql`
             fluid(maxWidth: 300, quality: 100) {
               ...GatsbyImageSharpFluid
               presentationWidth
+            }
+          }
+        }
+        featuredimage: patternArt {
+          childImageSharp {
+            resize(width: 1200) {
+              src
+              height
+              width
             }
           }
         }

--- a/src/templates/resources.js
+++ b/src/templates/resources.js
@@ -64,11 +64,20 @@ ResourcesTemplate.propTypes = {
   contentComponent: PropTypes.func,
 };
 
-const Resources = ({ data }) => {
+const Resources = ({ data, location }) => {
   const { markdownRemark: post } = data;
+  const { frontmatter } = post;
+  const image = frontmatter.featuredimage
+    ? frontmatter.featuredimage.childImageSharp.resize
+    : null;
 
   return (
-    <Layout>
+    <Layout
+      description={frontmatter.description}
+      title={frontmatter.title}
+      pathname={location.pathname}
+      metaImage={image}
+    >
       <ResourcesTemplate
         contentComponent={HTMLContent}
         {...post.frontmatter}
@@ -100,6 +109,15 @@ export const aboutPageQuery = graphql`
             fluid(maxWidth: 300, quality: 100) {
               ...GatsbyImageSharpFluid
               presentationWidth
+            }
+          }
+        }
+        featuredimage: resourceArt {
+          childImageSharp {
+            resize(width: 1200) {
+              src
+              height
+              width
             }
           }
         }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -69,6 +69,7 @@ collections:
           - {label: "subTitle (is the actual displayed title on the page)", name: "subTitle", widget: "string"}
           - {label: "Body", name: "body", widget: "markdown"}
           - {label: "Last Updated Date", name: "updatedDate", widget: "datetime"}
+          - {label: "Featured Image", name: "featuredimage", widget: image, required: false}
   - name: "resources"
     label: "Downloadable Resources"
     folder: "content/resources"
@@ -102,3 +103,4 @@ collections:
       - {label: "Template Key", name: "templateKey", widget: "hidden", default: "info-page"}
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Body", name: "body", widget: "markdown"}
+      - {label: "Featured Image", name: "featuredimage", widget: image, required: false}


### PR DESCRIPTION
This fixes #124 

There are still properties that need to be set properly but
this addresses the most immediate needs.

All pages should now pass appropriate values for title, description, and
image metadata to the seo component. The least invasive change was to
pass the props on through the layout component but the more correct
might be to directly reference the seo component in the templates.

Setting the images to 1200 for now since that's the recommended width
for social cards but it may need some tweaking.

Also specify the base site url for the different environments:

The facebook and twitter crawlers expect the metadata links to use
absolute urls so in order to be able test to the seo changes we needed
to configure the base url and the quickest way seemed to hardcode it for
staging and this particular pull request in the `netlify.toml`.
These could be updated as needed for testing.

