### PR TITLE
Add Visual Studio Code development container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# To fully customize the contents of this image, use the following Dockerfile instead:
+# https://github.com/microsoft/vscode-dev-containers/tree/v0.128.0/containers/javascript-node-12/.devcontainer/Dockerfile
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-12
+
+# ** [Optional] Uncomment this section to install additional packages. **
+#
+# RUN apt-get update \
+#     && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# Remove GPG keys from Node.js image to allow VS Code to copy GPG keys from host
+RUN rm ~/.gnupg/pubring.kbx ~/.gnupg/trustdb.gpg
+
+# Install correct Node.js version
+COPY .nvmrc .
+RUN /bin/bash -c "source $NVM_DIR/nvm.sh && nvm install && rm ./.nvmrc" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.128.0/containers/javascript-node-12
+{
+	"name": "Node.js 12",
+	"dockerFile": "Dockerfile",
+	"context": "..",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+		"esbenp.prettier-vscode"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [8000],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "source $NVM_DIR/nvm.sh && nvm install && yarn install",
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "node"
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# This ignore file is used to limit the build context sent to Docker
+# when building the VS Code dev container
+*
+!.nvmrc


### PR DESCRIPTION
Using the "Node.js 12 & JavaScript" template provided by VS Code, create a development container configuration that sets up a Dockerized development environment for working on the site.

To ensure the correct Node.js version is installed, Docker needs to copy over `.nvmrc`. To limit the build context (files) sent to Docker while building the container, a `.dockerignore` file was added in the root of the project.

The main rationale behind this pull request is to allow contributors to get set up quickly with a consistent development environment that's just a click and `yarn start` away. This configuration can be used with any of the following:

- Visual Studio Code and Docker (locally)
- [Visual Studio Codespaces][vscp] (in Visual Studio Code or in a browser)
- [GitHub Codespaces][ghcp] (in Visual Studio Code or in a browser)

When GitHub Codespaces becomes more generally available, it will be by far the easiest and quickest way for contributors to get started.

[vscp]: https://visualstudio.microsoft.com/services/visual-studio-codespaces/
[ghcp]: https://github.com/features/codespaces